### PR TITLE
[Feat] #43 -LocationSelectView Reactor 바인딩

### DIFF
--- a/EatsOkay/LocationSelectView/LocationSelectReactor.swift
+++ b/EatsOkay/LocationSelectView/LocationSelectReactor.swift
@@ -46,7 +46,7 @@ final class LocationSelectReactor: Reactor {
         @Pulse var pickerViewinitialRows: (firstRow: Int, secondRow: Int)?
         var selectedItem: (firstRow: Int, secondRow: Int)
         @Pulse var nextViewState: Void?
-        @Pulse var alretState: Void?
+        @Pulse var alertState: Void?
         @Pulse var error: Error?
     }
     
@@ -212,7 +212,7 @@ final class LocationSelectReactor: Reactor {
             newState.nextViewState = location
             
         case let .setAlert(alretTriger):
-            newState.alretState = alretTriger
+            newState.alertState = alretTriger
             
         case let .setError(error):
             newState.error = error

--- a/EatsOkay/LocationSelectView/LocationSelectView.swift
+++ b/EatsOkay/LocationSelectView/LocationSelectView.swift
@@ -171,8 +171,8 @@ final class LocationSelectView: UIViewController, View {
     
     private func bindState(reactor: LocationSelectReactor) {
         reactor.pulse(\.$pickerViewData)
-            .map { $0 as PickerViewViewAdapter.Element }
-            .bind(to: pickerView.rx.items(adapter: PickerViewViewAdapter()))
+            .map { $0 as PickerViewAdapter.Element }
+            .bind(to: pickerView.rx.items(adapter: PickerViewAdapter()))
             .disposed(by: disposeBag)
         
         reactor.pulse(\.$pickerViewinitialRows)
@@ -184,7 +184,7 @@ final class LocationSelectView: UIViewController, View {
             }
             .disposed(by: disposeBag)
         
-        reactor.pulse(\.$alretState)
+        reactor.pulse(\.$alertState)
             .withUnretained(self)
             .bind { vc, void in
                 guard void != nil else { return }

--- a/EatsOkay/LocationSelectView/LocationSelectView.swift
+++ b/EatsOkay/LocationSelectView/LocationSelectView.swift
@@ -11,7 +11,10 @@ import RxSwift
 import RxCocoa
 import ReactorKit
 
-final class LocationSelectView: UIViewController {
+final class LocationSelectView: UIViewController, View {
+    
+    var disposeBag: DisposeBag = DisposeBag()
+    let reactor: LocationSelectReactor
     
     let guideLabel: UILabel = {
         
@@ -88,10 +91,20 @@ final class LocationSelectView: UIViewController {
     
     let startButton = CustomButton(title: "설정하기")
     
+    init(reactor: LocationSelectReactor) {
+        self.reactor = reactor
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
         setConstraints()
+        bind(reactor: reactor)
     }
     
     private func configureUI() {
@@ -127,5 +140,75 @@ final class LocationSelectView: UIViewController {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
             $0.centerX.equalTo(view.snp.centerX)
         }
+    }
+    
+    func bind(reactor: LocationSelectReactor) {
+        bindAction(reactor: reactor)
+        bindState(reactor: reactor)
+    }
+    
+    private func bindAction(reactor: LocationSelectReactor) {
+        Observable.just(Void())
+            .map { Reactor.Action.initialFetch }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        locationButton.rx.tap
+            .map { Reactor.Action.locationButtonTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        pickerView.rx.itemSelected
+            .map { Reactor.Action.pickerViewChanged(component: $0.component, row: $0.row) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        startButton.rx.tap
+            .map { Reactor.Action.nextButtonTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+    }
+    
+    private func bindState(reactor: LocationSelectReactor) {
+        reactor.pulse(\.$pickerViewData)
+            .map { $0 as PickerViewViewAdapter.Element }
+            .bind(to: pickerView.rx.items(adapter: PickerViewViewAdapter()))
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$pickerViewinitialRows)
+            .withUnretained(self)
+            .bind { vc, rows in
+                guard let rows else { return }
+                vc.pickerView.selectRow(rows.firstRow, inComponent: 0, animated: true)
+                vc.pickerView.selectRow(rows.secondRow, inComponent: 1, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$alretState)
+            .withUnretained(self)
+            .bind { vc, void in
+                guard void != nil else { return }
+                let locationAlert = CustomLocationAlert()
+                vc.present(locationAlert, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$nextViewState)
+            .withUnretained(self)
+            .bind { vc, test in
+                guard test != nil else { return }
+                let testView = MainViewController()
+                vc.present(testView, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$error)
+            .withUnretained(self)
+            .bind { vc, error in
+                guard error != nil else { return }
+                guard let errorString = error?.localizedDescription else { return }
+                print(errorString)
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/EatsOkay/LocationSelectView/PickerViewAdapter.swift
+++ b/EatsOkay/LocationSelectView/PickerViewAdapter.swift
@@ -1,5 +1,5 @@
 //
-//  PickerViewViewAdapter.swift
+//  PickerViewAdapter.swift
 //  EatsOkay
 //
 //  Created by LCH on 6/16/25.
@@ -9,7 +9,7 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-final class PickerViewViewAdapter: NSObject,
+final class PickerViewAdapter: NSObject,
                                    UIPickerViewDataSource,
                                    UIPickerViewDelegate,
                                    RxPickerViewDataSourceType,

--- a/EatsOkay/LocationSelectView/PickerViewViewAdapter.swift
+++ b/EatsOkay/LocationSelectView/PickerViewViewAdapter.swift
@@ -1,0 +1,49 @@
+//
+//  PickerViewViewAdapter.swift
+//  EatsOkay
+//
+//  Created by LCH on 6/16/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+final class PickerViewViewAdapter: NSObject,
+                                   UIPickerViewDataSource,
+                                   UIPickerViewDelegate,
+                                   RxPickerViewDataSourceType,
+                                   SectionedViewDataSourceType {
+    
+    typealias Element = [[CustomStringConvertible]]
+    private var items: [[CustomStringConvertible]] = []
+
+    func model(at indexPath: IndexPath) throws -> Any {
+        items[indexPath.section][indexPath.row]
+    }
+    
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        items.count
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        items[component].count
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        let label = UILabel()
+        label.text = items[component][row].description
+        
+        label.textColor = .customColor(hexCode: .neutral950)
+        label.font = .customFontForButton(weight: .w900)
+        label.textAlignment = .center
+        return label
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, observedEvent: Event<Element>) {
+        Binder(self) { (adapter, items) in
+            adapter.items = items
+            pickerView.reloadAllComponents()
+        }.on(observedEvent)
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #43

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- LocationSelectView Reactor 바인딩

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 바인딩 로직
- 오타

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- UIPickerView가 스크롤 되고있는 상태에서 설정하기 버튼 클릭시 스크롤 전에 아이템이 선택되는 문제점이 있습니다
해당 문제점은 pickerView에 itemSelected가 아닌 modelSelected로 리펙토링 해보고 문제점이 해결된다면 적용하도록 하겠습니다.

![image](https://github.com/user-attachments/assets/5ad66a78-f7f9-483a-8005-241a71b986c8)


## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
