### PR TITLE
[Feat] #51 - 행간 적용을 위한 공통 NSMutableAttributedString 메서드 구현

### DIFF
--- a/EatsOkay/Common/AttributedStringManager.swift
+++ b/EatsOkay/Common/AttributedStringManager.swift
@@ -24,6 +24,7 @@ struct AttributedStringManager {
         let baselineOffset = (targetLineHeight - font.lineHeight) / 2
         
         let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = alignment
         paragraphStyle.lineHeightMultiple = lineHeightMultiple
         paragraphStyle.minimumLineHeight = targetLineHeight
         paragraphStyle.maximumLineHeight = targetLineHeight
@@ -51,6 +52,7 @@ struct AttributedStringManager {
         let baselineOffset = (targetLineHeight - font.lineHeight) / 2
         
         let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = alignment
         paragraphStyle.lineHeightMultiple = lineHeightMultiple
         paragraphStyle.minimumLineHeight = targetLineHeight
         paragraphStyle.maximumLineHeight = targetLineHeight

--- a/EatsOkay/Common/AttributedStringManager.swift
+++ b/EatsOkay/Common/AttributedStringManager.swift
@@ -1,0 +1,65 @@
+//
+//  AttributedStringManager.swift
+//  EatsOkay
+//
+//  Created by LCH on 6/17/25.
+//
+
+import UIKit
+
+struct AttributedStringManager {
+    
+    static func configureString(
+        text: String, font: UIFont, color: UIColor.CustomColor, alignment: NSTextAlignment = .left
+    ) -> NSMutableAttributedString {
+        
+        let attributedString = NSMutableAttributedString(string: text)
+        let range = NSRange(location: 0, length: attributedString.length)
+        
+        let customColor = UIColor.customColor(hexCode: color)
+
+        let lineHeightRatio: CGFloat = 1.41
+        let targetLineHeight = font.pointSize * lineHeightRatio
+        let lineHeightMultiple = targetLineHeight / font.lineHeight
+        let baselineOffset = (targetLineHeight - font.lineHeight) / 2
+        
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = lineHeightMultiple
+        paragraphStyle.minimumLineHeight = targetLineHeight
+        paragraphStyle.maximumLineHeight = targetLineHeight
+        
+        attributedString.addAttribute(.font, value: font, range: range)
+        attributedString.addAttribute(.foregroundColor, value: customColor, range: range)
+        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
+        attributedString.addAttribute(.baselineOffset, value: baselineOffset, range: range)
+        
+        return attributedString
+    }
+    
+    static func configureString(
+        text: String, font: UIFont, color: UIColor.CustomColor, alignment: NSTextAlignment = .left
+    ) -> AttributedString {
+        
+        let attributedString = NSMutableAttributedString(string: text)
+        let range = NSRange(location: 0, length: attributedString.length)
+        
+        let customColor = UIColor.customColor(hexCode: color)
+
+        let lineHeightRatio: CGFloat = 1.41
+        let targetLineHeight = font.pointSize * lineHeightRatio
+        let lineHeightMultiple = targetLineHeight / font.lineHeight
+        let baselineOffset = (targetLineHeight - font.lineHeight) / 2
+        
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = lineHeightMultiple
+        paragraphStyle.minimumLineHeight = targetLineHeight
+        paragraphStyle.maximumLineHeight = targetLineHeight
+        
+        attributedString.addAttribute(.font, value: font, range: range)
+        attributedString.addAttribute(.foregroundColor, value: customColor, range: range)
+        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
+        attributedString.addAttribute(.baselineOffset, value: baselineOffset, range: range)
+        
+        return AttributedString(attributedString)
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #51

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 행간 적용을 위한 공통 NSMutableAttributedString 메서드 구현

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 상하 동일한 행간 적용을 위한 계산 로직

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 메서드 오버로딩을 사용하여 configureString은 NSAttributedString과 AttributedString에서 모두 사용가능

계산 과정
```swift
// 적용하고자하는 lineHeight 비율(1.41은 141%를 의미)
let lineHeightRatio: CGFloat = 1.41 // figma상 140%이나 소수점 오차 보정을 위한 1% 추가

// font사이즈와 lineHeightRatio를 통한 목표 높이 계산
let targetLineHeight = font.pointSize * lineHeightRatio

// targetLineHeight를 font.lineHeight로 나눠 실제 반영할 배율 계산
let lineHeightMultiple = targetLineHeight / font.lineHeight // figma상 Dev Mode에 나온 1.17이 여기서 계산됨

// UIKit에서 LineHeight는 상단에 적용되므로 보정을 위해 targetLineHeight에서 font.lineHeight를 빼서
// 폰트 크기를 제외한 lineHeight 영역의 높이를 2로 나눠서 baselineOffset에 적용할 값 계산
let baselineOffset = (targetLineHeight - font.lineHeight) / 2

let paragraphStyle = NSMutableParagraphStyle()
paragraphStyle.lineHeightMultiple = lineHeightMultiple  // 계산된 lineHeightMultiple 반영

// minimumLineHeight와 maximumLineHeight를 targetLineHeight로 설정하여
// lineHeight는 항상 targetLineHeight가 되도록 강제
paragraphStyle.minimumLineHeight = targetLineHeight
paragraphStyle.maximumLineHeight = targetLineHeight
```

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
