### PR TITLE
[Fix] #79 - CustomLocationAlert 메모리 누수

### DIFF
--- a/EatsOkay/Common/UIComponent/CustomLocationAlert.swift
+++ b/EatsOkay/Common/UIComponent/CustomLocationAlert.swift
@@ -163,13 +163,13 @@ final class CustomLocationAlert: UIViewController {
     }
     
     private func addAction() {
-        cancelButton.addAction(UIAction(handler: { _ in
-            self.dismiss(animated: true)
+        cancelButton.addAction(UIAction(handler: { [weak self] _ in
+            self?.dismiss(animated: true)
         }), for: .touchUpInside)
         
-        goSettingButton.addAction(UIAction(handler: { _ in
+        goSettingButton.addAction(UIAction(handler: { [weak self] _ in
             guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-            self.dismiss(animated: true)
+            self?.dismiss(animated: true)
             UIApplication.shared.open(url)
         }), for: .touchUpInside)
     }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #79

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- CustomLocationAlert 강한 순환참조로 인한 메모리 누수 수정

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

- Xcode 메모리 그래프에서 dismiss시 인스턴스 메모리에서 해제 확인했습니다.
 
- 수정전 - CustomLocationAlert 호출 후 dismiss가 되어도 메모리에서 해제 안됨
![스크린샷 2025-06-19 오전 12 42 00(2)](https://github.com/user-attachments/assets/80eb36c0-bca5-47a5-b9f0-a56eaddcc821)

- 수정후 - CustomLocationAlert 호출 후 dismiss가 되면 메모리에서 해제 됨
![스크린샷 2025-06-19 오전 12 48 05(2)](https://github.com/user-attachments/assets/4ca6e69d-7298-4ddc-aba2-2d6091fa92d1) 

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인