### PR TITLE
[Feat] #81 - ToastMessage 기능 구현

### DIFF
--- a/EatsOkay/App/Assets.xcassets/Images/AlertCircle.imageset/AlertCircle.svg
+++ b/EatsOkay/App/Assets.xcassets/Images/AlertCircle.imageset/AlertCircle.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 10V5.5M10 13.3354V13.375M19 10C19 14.9706 14.9706 19 10 19C5.02944 19 1 14.9706 1 10C1 5.02944 5.02944 1 10 1C14.9706 1 19 5.02944 19 10Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/EatsOkay/App/Assets.xcassets/Images/AlertCircle.imageset/Contents.json
+++ b/EatsOkay/App/Assets.xcassets/Images/AlertCircle.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "AlertCircle.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/EatsOkay/Common/UIView+.swift
+++ b/EatsOkay/Common/UIView+.swift
@@ -1,0 +1,58 @@
+//
+//  UIView+.swift
+//  EatsOkay
+//
+//  Created by LCH on 6/19/25.
+//
+
+import UIKit
+
+extension UIView {
+    
+    func showToast(message: String, alpha: CGFloat) {
+        
+        let imageView = UIImageView(image: .alertCircle)
+        imageView.contentMode = .scaleAspectFit
+        
+        let label = UILabel()
+        label.attributedText = AttributedStringManager.configureString(
+            text: message,
+            font: .customFontForBody(weight: .w400),
+            color: .bgColor,
+            alignment: .center
+        )
+        
+        let stack = UIStackView(arrangedSubviews: [imageView, label])
+        stack.spacing = 8
+        stack.alignment = .center
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.layoutMargins = UIEdgeInsets(top: 10, left: 12, bottom: 10, right: 12)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.alpha = 0.0
+        stack.layer.cornerRadius = 12
+        stack.clipsToBounds = true
+        stack.backgroundColor = .customColor(hexCode: .neutral950).withAlphaComponent(alpha)
+        
+        self.addSubview(stack)
+        
+        stack.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(self.safeAreaLayoutGuide.snp.bottom).inset(80)
+        }
+        
+        imageView.snp.makeConstraints {
+            $0.size.equalTo(16)
+        }
+        
+        UIView.animate(withDuration: 0.5, delay: 0.0, options: .curveEaseIn, animations: {
+            stack.alpha = 1.0
+        }, completion: { _ in
+            
+            UIView.animate(withDuration: 0.5, delay: 2.0, options: .curveEaseOut, animations: {
+                stack.alpha = 0.0
+            }, completion: { _ in
+                stack.removeFromSuperview()
+            })
+        })
+    }
+}

--- a/EatsOkay/Common/UIView+.swift
+++ b/EatsOkay/Common/UIView+.swift
@@ -16,6 +16,7 @@ extension UIView {
         imageView.contentMode = .scaleAspectFit
         
         let label = UILabel()
+        label.numberOfLines = 0
         label.attributedText = AttributedStringManager.configureString(
             text: message,
             font: .customFontForBody(weight: .w400),

--- a/EatsOkay/Common/UIView+.swift
+++ b/EatsOkay/Common/UIView+.swift
@@ -6,10 +6,11 @@
 //
 
 import UIKit
+import SnapKit
 
 extension UIView {
     
-    func showToast(message: String, alpha: CGFloat) {
+    func showToast(message: String, alpha: CGFloat, constraints: @escaping (_ make: ConstraintMaker) -> Void) {
         
         let imageView = UIImageView(image: .alertCircle)
         imageView.contentMode = .scaleAspectFit
@@ -35,10 +36,7 @@ extension UIView {
         
         self.addSubview(stack)
         
-        stack.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(self.safeAreaLayoutGuide.snp.bottom).inset(80)
-        }
+        stack.snp.makeConstraints { constraints($0) }
         
         imageView.snp.makeConstraints {
             $0.size.equalTo(16)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #81

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- ToastMessage 기능 구현

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 디자인과 레이아웃 일치 여부
- closure 사용의 적합성

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- View마다 ToastMessage의 위치가 다를 수 있어서 constraints를 closure를 통해 외부에서 주입받습니다.

<img src="https://github.com/user-attachments/assets/b96f1978-a7fd-48a4-a353-c180d88da677" width="500" />


## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
