### PR TITLE
[Fix] #114 - 상단 카테고리 버튼의 그림자가 가려지는 현상

### DIFF
--- a/EatsOkay/Home/HomeViewController.swift
+++ b/EatsOkay/Home/HomeViewController.swift
@@ -22,6 +22,15 @@ final class HomeViewController: UIViewController, View {
     init(reactor: HomeReactor) {
         self.reactor = reactor
         super.init(nibName: nil, bundle: nil)
+
+        let width = UIScreen.main.bounds.width
+        let height: CGFloat = 4
+        let cgRect = CGRect(x: 0, y: 0, width: width, height: height)
+
+        categoryBtnShadowView.layer.shadowPath = UIBezierPath(
+            roundedRect: cgRect,
+            cornerRadius: 0
+        ).cgPath
     }
 
     required init?(coder: NSCoder) {
@@ -29,9 +38,19 @@ final class HomeViewController: UIViewController, View {
     }
     
     private let locationHeaderView = LocationHeaderView()
-    private let categoryBtnShadowView = UIView()
     private let categoryButtonView = CategoryBtnView()
     private let tableView = UITableView()
+
+    private lazy var categoryBtnShadowView: UIView = {
+        let shadowView = UIView()
+        shadowView.backgroundColor = .white
+        shadowView.layer.shadowColor = UIColor.customColor(hexCode: .neutral950).cgColor
+        shadowView.layer.shadowOpacity = 0.3
+        shadowView.layer.shadowOffset = CGSize(width: 0, height: 2)
+        shadowView.layer.shadowRadius = 20
+        shadowView.layer.masksToBounds = false
+        return shadowView
+    }()
 
 
     typealias DataSource = RxTableViewSectionedAnimatedDataSource<HomeSectionOfCellModel>
@@ -53,11 +72,13 @@ final class HomeViewController: UIViewController, View {
     private func configureUI() {
         view.backgroundColor = .white
 
-        [locationHeaderView, tableView, categoryButtonView]
+        [locationHeaderView, tableView, categoryButtonView, categoryBtnShadowView]
             .forEach { view.addSubview($0) }
 
         tableView.rowHeight = 260
         tableView.separatorStyle = .none
+
+        view.bringSubviewToFront(categoryButtonView)
     }
 
     private func setConstraints() {
@@ -66,15 +87,21 @@ final class HomeViewController: UIViewController, View {
             make.height.equalTo(92)
         }
 
+        tableView.snp.makeConstraints { make in
+            make.top.equalTo(categoryButtonView.snp.bottom)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+
         categoryButtonView.snp.makeConstraints { make in
             make.top.equalTo(locationHeaderView.snp.bottom)
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(72)
         }
 
-        tableView.snp.makeConstraints { make in
-            make.top.equalTo(categoryButtonView.snp.bottom)
-            make.leading.trailing.bottom.equalToSuperview()
+        categoryBtnShadowView.snp.makeConstraints { make in
+            make.top.equalTo(categoryButtonView.snp.bottom).offset(-4)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(4)
         }
     }
 

--- a/EatsOkay/Home/subViews/CategoryBtnView.swift
+++ b/EatsOkay/Home/subViews/CategoryBtnView.swift
@@ -32,21 +32,6 @@ final class CategoryBtnView: UIView {
         scrollView.addSubview(btnStackView)
 
         scrollView.isPagingEnabled = true
-
-        let shadowLayer = CALayer()
-        shadowLayer.frame = CGRect(
-            x: 0,
-            y: 72,
-            width: UIScreen.main.bounds.width,
-            height: 2
-        )
-        shadowLayer.shadowColor = UIColor.black.cgColor
-        shadowLayer.shadowOpacity = 0.08
-        shadowLayer.shadowOffset = CGSize(width: 0, height: 2)
-        shadowLayer.shadowRadius = 20
-        shadowLayer.shadowPath = UIBezierPath(rect: shadowLayer.bounds).cgPath
-        scrollView.layer.addSublayer(shadowLayer)
-
         return scrollView
     }()
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #114

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
![simulator_screenshot_876FF436-0E20-4953-A40D-003C9950B60A 1](https://github.com/user-attachments/assets/68c7f038-f021-45d2-8ad8-72bad5de9b73)
[CategoryBtnView]
- CategoryBtnView 내부에 적용한 layer가 tableView에 ContentView에 가려지는 현상이 있어 이를 삭제하였습니다

[HomeViewController]
- HomeViewController 내부에 그림자 전용 View(categoryBtnShadowView)를 만들고, 그림자를 설정하였습니다
- 초기화 시점에 path 값을 계산할 수 있도록, categoryBtnShadowView의 path 사이즈를 설정해주었습니다

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- init 시점에 shadowPath의 영역을 지정해주었습니다
 




## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
``` swift
    override func viewDidLayoutSubviews() {
        categoryBtnShadowView.layer.shadowPath = UIBezierPath(
            roundedRect: categoryBtnShadowView.bounds,
            cornerRadius: 0
        ).cgPath
    }
```
- 위 코드로도 동일한 동작은 가능하나, 그림자 영역 자체가 정적으로 유지되는 영역이라서 init 시점에 적용하였습니다

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
