### PR TITLE
[Fix] #134 - LocationSelectView-HomeView간 화면전환 문제

### DIFF
--- a/EatsOkay/Home/HomeViewController.swift
+++ b/EatsOkay/Home/HomeViewController.swift
@@ -170,7 +170,7 @@ final class HomeViewController: UIViewController, View {
             .bind(onNext: { vc, _ in
                 let reactor = LocationSelectReactor()
                 let locationVC = LocationSelectView(reactor: reactor)
-                vc.navigationController?.setViewControllers([locationVC], animated: true)
+                vc.navigationController?.pushViewController(locationVC, animated: true)
             })
             .disposed(by: disposeBag)
 

--- a/EatsOkay/LocationSelectView/LocationSelectView.swift
+++ b/EatsOkay/LocationSelectView/LocationSelectView.swift
@@ -188,9 +188,20 @@ final class LocationSelectView: UIViewController, View {
             .compactMap { $0 }
             .withUnretained(self)
             .bind { vc, _ in
-                let reactor = HomeReactor()
-                let homeVC = HomeViewController(reactor: reactor)
-                vc.navigationController?.setViewControllers([homeVC], animated: true)
+                if let rootVC = vc.navigationController?.viewControllers.first {
+                    switch rootVC {
+                    case is HomeViewController:
+                        vc.navigationController?.popViewController(animated: true)
+                    case is OnboardingViewController:
+                        let reactor = HomeReactor()
+                        let homeVC = HomeViewController(reactor: reactor)
+                        vc.navigationController?.setViewControllers([homeVC], animated: true)
+                    default:
+                        let reactor = HomeReactor()
+                        let homeVC = HomeViewController(reactor: reactor)
+                        vc.navigationController?.pushViewController(homeVC, animated: true)
+                    }
+                }
             }
             .disposed(by: disposeBag)
         

--- a/EatsOkay/LocationSelectView/LocationSelectView.swift
+++ b/EatsOkay/LocationSelectView/LocationSelectView.swift
@@ -192,14 +192,10 @@ final class LocationSelectView: UIViewController, View {
                     switch rootVC {
                     case is HomeViewController:
                         vc.navigationController?.popViewController(animated: true)
-                    case is OnboardingViewController:
-                        let reactor = HomeReactor()
-                        let homeVC = HomeViewController(reactor: reactor)
-                        vc.navigationController?.setViewControllers([homeVC], animated: true)
                     default:
                         let reactor = HomeReactor()
                         let homeVC = HomeViewController(reactor: reactor)
-                        vc.navigationController?.pushViewController(homeVC, animated: true)
+                        vc.navigationController?.setViewControllers([homeVC], animated: true)
                     }
                 }
             }


### PR DESCRIPTION

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #134

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
<변경내용>
- LocationSelectView-HomeView간 화면전환 push, pop으로 변경
- #132 수정에 따른 화면전환 로직 분기처리 변경

<변경사유>
- LocationSelectView - HomeView간 화면전환시 setViewControllers로 되어있어 LocationSelectView로 이동 후 돌아오면 새로운 HomeView 인스턴스로 표시되어 사용자가 선택한 카테고리가 유지되지 않고 새로운 인스턴스의 초기값이 표시됨
- 화면전환간 Animation이 HIG에 적합하지 않음

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 화면전환 로직 분기처리

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
