### PR TITLE
[Fix] #207 - SummaryView와 LocationView Gesture 문제로 인한 런타임 에러 발생

### DIFF
--- a/EatsOkay/Sources/Detail/Reactor/DetailReactor.swift
+++ b/EatsOkay/Sources/Detail/Reactor/DetailReactor.swift
@@ -357,7 +357,7 @@ extension DetailReactor {
             return .just(cachedUri)
         }
         // photoName이 없으면 빈 문자열 반환
-        guard !photoName.isEmpty else { return .just("") }
+        guard !photoName.isEmpty else { return .just("DefaultImage") }
         // 캐시에 없으면 네트워크 요청
         return NetworkManager.shared.fetchImage(mediaName: photoName)
             .map { [weak self] googleUri in

--- a/EatsOkay/Sources/Detail/View/DetailTableViewCell.swift
+++ b/EatsOkay/Sources/Detail/View/DetailTableViewCell.swift
@@ -212,7 +212,7 @@ class DetailTableViewCell: UITableViewCell {
         }
         
         // photoNames이 빈문자열이면 DefaultImage 표시
-        if storeInfo.photosNames != "" {
+        if storeInfo.photosNames != "DefaultImage" {
             if let url = URL(string: storeInfo.photosNames) {
                 storeImageView.kf.setImage(with: url)
             }

--- a/EatsOkay/Sources/Summary/Reactor/SummaryReactor.swift
+++ b/EatsOkay/Sources/Summary/Reactor/SummaryReactor.swift
@@ -159,7 +159,7 @@ class SummaryReactor: Reactor {
         return newState
     }
     
-    func makeDataSources(with imageUrls: [String]) -> Mutation {
+    private func makeDataSources(with imageUrls: [String]) -> Mutation {
         
         let storeInfo = currentState.storeInfo
         

--- a/EatsOkay/Sources/Summary/Reactor/SummaryReactor.swift
+++ b/EatsOkay/Sources/Summary/Reactor/SummaryReactor.swift
@@ -44,7 +44,7 @@ class SummaryReactor: Reactor {
         var shouldPop: Bool = false
         var webViewUrl: String? = nil
         var shouldPresentWebView: Bool = false
-        var currentImagePage: Int = 1
+        var currentImagePage: (Int, Int) = (1, 1)
         @Pulse var nationalNumber: String?
         @Pulse var setDetailPhoto: DetailPhotos?
     }
@@ -57,87 +57,40 @@ class SummaryReactor: Reactor {
             
             let photos = storeInfo.photos ?? []
             
-            let secondImageName = photos.count > 1 ? photos[1].name : "DefaultImage"
-            let thirdImageName  = photos.count > 2 ? photos[2].name : "DefaultImage"
+            switch photos.count {
+                
+            case 0, 1:
+                let imageUrls = [firstImageUrl]
+                let dataSources = makeDataSources(with: imageUrls)
+                return Observable.just(dataSources)
+
+            case 2:
+                let secondName = photos[1].name
+                return NetworkManager.shared.fetchImage(mediaName: secondName)
+                    .asObservable()
+                    .withUnretained(self)
+                    .map { reactor, second in
+                        let imageUrls = [firstImageUrl, second.photoUri]
+                        return reactor.makeDataSources(with: imageUrls)
+                    }
+
+            default:
+                let secondName = photos[1].name
+                let thirdName  = photos[2].name
+
+                let secondImage = NetworkManager.shared.fetchImage(mediaName: secondName).map { $0.photoUri }
+                let thirdImage  = NetworkManager.shared.fetchImage(mediaName: thirdName).map { $0.photoUri }
+
+                return Single.zip(secondImage, thirdImage)
+                    .asObservable()
+                    .withUnretained(self)
+                    .map { reactor, response in
+                        let imageUrls = [firstImageUrl, response.0, response.1]
+                        return reactor.makeDataSources(with: imageUrls)
+                    }
+                    
+            }
             
-            let secondImage: Single<String> = secondImageName == "DefaultImage" ? .just("DefaultImage")
-            : NetworkManager.shared.fetchImage(mediaName: secondImageName).map { $0.photoUri }
-            
-            let thirdImage: Single<String> = thirdImageName == "DefaultImage" ? .just("DefaultImage")
-            : NetworkManager.shared.fetchImage(mediaName: thirdImageName).map { $0.photoUri }
-            
-            return Single.zip(secondImage, thirdImage)
-                .map { secondImageUrl, thirdImageUrl in
-                    // 섹션 1
-                    let photoUri: [SummarySectionModel.CellModel] = [
-                        .summaryImageCell(
-                            .init(photosUrl: [firstImageUrl, secondImageUrl, thirdImageUrl])
-                        )
-                    ]
-                    let imageSection = SummarySectionModel(section: .summaryImage, items: photoUri)
-                    
-                    // 섹션 2
-                    let infoItems: [SummarySectionModel.CellModel] = [
-                        .summaryInfoCell(.init(
-                            storeName: storeInfo.displayName,
-                            storeAddress: storeInfo.formattedAddress,
-                            storeType: storeInfo.primaryTypeDisplayName,
-                            rate: "\(storeInfo.rating)",
-                            reviewCount: "리뷰 \(storeInfo.userRatingCount)개",
-                            isOpen: storeInfo.currentOpeningHours.openNow,
-                            openInfo: OpeningHours.getTodayClosingOrTomorrowOpening(openingHours: storeInfo.currentOpeningHours),
-                            storePhoneNumber: storeInfo.nationalPhoneNumber))
-                    ]
-                    let infoSection = SummarySectionModel(section: .summaryInfo, items: infoItems)
-                    
-                    // 섹션 3
-                    let hasFeatureInfo = (storeInfo.goodForGroups ?? false) ||
-                    (storeInfo.takeout ?? false) ||
-                    (storeInfo.reservable ?? false) ||
-                    (storeInfo.parkingOptions?.freeParkingLot ?? false) ||
-                    (storeInfo.parkingOptions?.paidParkingLot ?? false) ||
-                    (storeInfo.parkingOptions?.freeStreetParking ?? false) ||
-                    (storeInfo.parkingOptions?.paidStreetParking ?? false) ||
-                    (storeInfo.parkingOptions?.valetParking ?? false) ||
-                    (storeInfo.parkingOptions?.freeGarageParking ?? false) ||
-                    (storeInfo.parkingOptions?.paidGarageParking ?? false)
-                    
-                    // 단체모임/포장/예약/주차 정보가 모두 false 또는 nil일 경우 빈 배열 반환
-                    let featuresItems: [SummarySectionModel.CellModel] = hasFeatureInfo ? [
-                        .summaryFeaturesCell(
-                            .init(
-                                goodForGroups: storeInfo.goodForGroups,
-                                takeout: storeInfo.takeout,
-                                reservable: storeInfo.reservable,
-                                parkingOptions: storeInfo.parkingOptions
-                            )
-                        )
-                    ] : []
-                    
-                    let featuresSection = SummarySectionModel(section: .summaryFeatures, items: featuresItems)
-                    
-                    // 섹션 4
-                    let centerLat = storeInfo.latitude
-                    let centerLon = storeInfo.longitude
-                    let mapImageUrl = NetworkManager.shared.fetchStaticURL(center: "\(centerLat),\(centerLon)")
-                    let mapItems: [SummarySectionModel.CellModel] = [
-                        .summaryMapCell(
-                            .init(imageUrl: mapImageUrl ?? "", address: storeInfo.formattedAddress)
-                        )
-                    ]
-                    let mapSection = SummarySectionModel(section: .summaryMap, items: mapItems)
-                    
-                    // 4개의 섹션 데이터들을 하나로 병합
-                    let dataSource: [SummarySectionModel] = [
-                        imageSection,
-                        infoSection,
-                        featuresSection,
-                        mapSection
-                    ]
-                    
-                    return Mutation.setSections(dataSource)
-                }
-                .asObservable()
         case .backButtonTapped:
             return .just(.shouldPop(true))
         case .webViewButtonTapped:
@@ -152,7 +105,7 @@ class SummaryReactor: Reactor {
                 if case let .setImagePage(page) = mutation {
                     let prev = self.currentState.currentImagePage
                     let now = page
-                    return prev == now ? false : true
+                    return prev.0 == now ? false : true
                 } else {
                     return true
                 }
@@ -166,7 +119,10 @@ class SummaryReactor: Reactor {
             let photoUri = currentState.setSections[0].items[0]
             switch photoUri {
             case .summaryImageCell(let photosUri):
-                let detailPhotos = DetailPhotos(storeName: storeName, selectedIndex: selectedIndex, photosUri: photosUri.photosUrl)
+                guard photosUri.photosUrl[0] != "DefaultImage" else {
+                    return .empty()
+                }
+                let detailPhotos = DetailPhotos(storeName: storeName, selectedIndex: selectedIndex.0, photosUri: photosUri.photosUrl)
                 return .just(.setDetailPhoto(detailPhotos))
             default :
                 return .empty()
@@ -188,12 +144,91 @@ class SummaryReactor: Reactor {
         case .dismissWebView:
             newState.shouldPresentWebView = false
         case .setImagePage(let page):
-            newState.currentImagePage = page
+            var photosCount = currentState.storeInfo.photos?.count ?? 1
+            
+            if photosCount > 2 {
+                photosCount = 3
+            }
+            
+            newState.currentImagePage = (page, photosCount)
         case .setNationalNumber(let nationalNumber):
             newState.nationalNumber = nationalNumber
         case .setDetailPhoto(let detailPhotos):
             newState.setDetailPhoto = detailPhotos
         }
         return newState
+    }
+    
+    func makeDataSources(with imageUrls: [String]) -> Mutation {
+        
+        let storeInfo = currentState.storeInfo
+        
+        let photoUri: [SummarySectionModel.CellModel] = [
+            .summaryImageCell(
+                .init(photosUrl: imageUrls)
+            )
+        ]
+        let imageSection = SummarySectionModel(section: .summaryImage, items: photoUri)
+        
+        // 섹션 2
+        let infoItems: [SummarySectionModel.CellModel] = [
+            .summaryInfoCell(.init(
+                storeName: storeInfo.displayName,
+                storeAddress: storeInfo.formattedAddress,
+                storeType: storeInfo.primaryTypeDisplayName,
+                rate: "\(storeInfo.rating)",
+                reviewCount: "리뷰 \(storeInfo.userRatingCount)개",
+                isOpen: storeInfo.currentOpeningHours.openNow,
+                openInfo: OpeningHours.getTodayClosingOrTomorrowOpening(openingHours: storeInfo.currentOpeningHours),
+                storePhoneNumber: storeInfo.nationalPhoneNumber))
+        ]
+        let infoSection = SummarySectionModel(section: .summaryInfo, items: infoItems)
+        
+        // 섹션 3
+        let hasFeatureInfo = (storeInfo.goodForGroups ?? false) ||
+        (storeInfo.takeout ?? false) ||
+        (storeInfo.reservable ?? false) ||
+        (storeInfo.parkingOptions?.freeParkingLot ?? false) ||
+        (storeInfo.parkingOptions?.paidParkingLot ?? false) ||
+        (storeInfo.parkingOptions?.freeStreetParking ?? false) ||
+        (storeInfo.parkingOptions?.paidStreetParking ?? false) ||
+        (storeInfo.parkingOptions?.valetParking ?? false) ||
+        (storeInfo.parkingOptions?.freeGarageParking ?? false) ||
+        (storeInfo.parkingOptions?.paidGarageParking ?? false)
+        
+        // 단체모임/포장/예약/주차 정보가 모두 false 또는 nil일 경우 빈 배열 반환
+        let featuresItems: [SummarySectionModel.CellModel] = hasFeatureInfo ? [
+            .summaryFeaturesCell(
+                .init(
+                    goodForGroups: storeInfo.goodForGroups,
+                    takeout: storeInfo.takeout,
+                    reservable: storeInfo.reservable,
+                    parkingOptions: storeInfo.parkingOptions
+                )
+            )
+        ] : []
+        
+        let featuresSection = SummarySectionModel(section: .summaryFeatures, items: featuresItems)
+        
+        // 섹션 4
+        let centerLat = storeInfo.latitude
+        let centerLon = storeInfo.longitude
+        let mapImageUrl = NetworkManager.shared.fetchStaticURL(center: "\(centerLat),\(centerLon)")
+        let mapItems: [SummarySectionModel.CellModel] = [
+            .summaryMapCell(
+                .init(imageUrl: mapImageUrl ?? "", address: storeInfo.formattedAddress)
+            )
+        ]
+        let mapSection = SummarySectionModel(section: .summaryMap, items: mapItems)
+        
+        // 4개의 섹션 데이터들을 하나로 병합
+        let dataSource: [SummarySectionModel] = [
+            imageSection,
+            infoSection,
+            featuresSection,
+            mapSection
+        ]
+        
+        return Mutation.setSections(dataSource)
     }
 }

--- a/EatsOkay/Sources/Summary/View/CustomHeaderView.swift
+++ b/EatsOkay/Sources/Summary/View/CustomHeaderView.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-class CustomHeaderView: UICollectionReusableView {
+final class CustomHeaderView: UICollectionReusableView {
     static let identifier = "HeaderCollectionReusableView"
     
     private let label = UILabel()

--- a/EatsOkay/Sources/Summary/View/SectionFourViewCell.swift
+++ b/EatsOkay/Sources/Summary/View/SectionFourViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Kingfisher
 
-class SectionFourViewCell: UICollectionViewCell {
+final class SectionFourViewCell: UICollectionViewCell {
     static let identifier = "SectionFourViewCell"
     
     required init?(coder: NSCoder) {

--- a/EatsOkay/Sources/Summary/View/SectionOneViewCell.swift
+++ b/EatsOkay/Sources/Summary/View/SectionOneViewCell.swift
@@ -52,21 +52,11 @@ class SectionOneViewCell: UICollectionViewCell {
     }()
     
     private let storeImageView = UIView()
-    private let contentButtons: [UIButton] = {
-        ["DefaultImage", "DefaultImage", "DefaultImage"].map { imageName in
-            let button = UIButton()
-            button.imageView?.contentMode = .scaleAspectFit
-            return button
-        }
-    }()
     
     private func configureUI() {
         contentView.backgroundColor = .white
         scrollView.addSubview(bgView)
         scrollView.addSubview(storeImageView)
-        
-        
-        contentButtons.forEach { storeImageView.addSubview($0) }
         
         [
             scrollView, photoPageLabel
@@ -92,23 +82,10 @@ class SectionOneViewCell: UICollectionViewCell {
         storeImageView.snp.makeConstraints {
             $0.edges.equalToSuperview()
             $0.height.equalToSuperview()
-            $0.width.equalToSuperview().multipliedBy(contentButtons.count)
         }
         
         bgView.snp.makeConstraints { make in
             make.height.equalTo(contentView.snp.height)
-        }
-        
-        for (index, view) in contentButtons.enumerated() {
-            view.snp.makeConstraints {
-                $0.top.bottom.equalToSuperview()
-                $0.width.equalTo(scrollView.snp.width)
-                if index == 0 {
-                    $0.leading.equalToSuperview()
-                } else {
-                    $0.leading.equalTo(contentButtons[index - 1].snp.trailing)
-                }
-            }
         }
         
         photoPageLabel.snp.makeConstraints { make in
@@ -121,24 +98,54 @@ class SectionOneViewCell: UICollectionViewCell {
     }
     
     func update(with: SummarySectionModel.CellModel) {
+        storeImageView.subviews.forEach { $0.removeFromSuperview() }
         switch with {
         case .summaryImageCell(let data):
-            contentButtons.forEach {
-                $0.rx.tap
+            
+            let contentsButtons = data.photosUrl.map { uri in
+                let button = UIButton()
+                button.imageView?.contentMode = .scaleAspectFit
+                
+                if let uri = URL(string: uri) {
+                    button.kf.setImage(with: uri, for: .normal, completionHandler:  { response in
+                        if case .failure = response {
+                            button.setImage(UIImage(named: "DefaultImage"), for: .normal)
+                        }
+                    })
+                    button.kf.setImage(with: uri, for: .highlighted, completionHandler:  { response in
+                        if case .failure = response {
+                            button.setImage(UIImage(named: "DefaultImage"), for: .highlighted)
+                        }
+                    })
+                } else {
+                    button.setImage(UIImage(named: "DefaultImage"), for: .normal)
+                    button.setImage(UIImage(named: "DefaultImage"), for: .highlighted)
+                }
+                
+                button.rx.tap
                     .withUnretained(self)
                     .bind { cell, _ in
                         cell.contentsButtonRelay.accept(Void())
                     }
                     .disposed(by: disposeBag)
+                
+                return button
             }
-            for (index, urlString) in data.photosUrl.enumerated() {
-                if index < contentButtons.count {
-                    if let url = URL(string: urlString) {
-                        contentButtons[index].kf.setImage(with: url, for: .normal)
-                        contentButtons[index].kf.setImage(with: url, for: .highlighted)
+            
+            contentsButtons.forEach { storeImageView.addSubview($0) }
+            
+            storeImageView.snp.makeConstraints {
+                $0.width.equalToSuperview().multipliedBy(data.photosUrl.count)
+            }
+            
+            for (index, view) in contentsButtons.enumerated() {
+                view.snp.makeConstraints {
+                    $0.top.bottom.equalToSuperview()
+                    $0.width.equalTo(scrollView.snp.width)
+                    if index == 0 {
+                        $0.leading.equalToSuperview()
                     } else {
-                        contentButtons[index].setImage(UIImage(named: "DefaultImage"), for: .normal)
-                        contentButtons[index].setImage(UIImage(named: "DefaultImage"), for: .highlighted)
+                        $0.leading.equalTo(contentsButtons[index - 1].snp.trailing)
                     }
                 }
             }
@@ -159,4 +166,3 @@ extension Reactive where Base: SectionOneViewCell {
             .asObservable()
     }
 }
-

--- a/EatsOkay/Sources/Summary/View/SectionOneViewCell.swift
+++ b/EatsOkay/Sources/Summary/View/SectionOneViewCell.swift
@@ -43,7 +43,7 @@ final class SectionOneViewCell: UICollectionViewCell {
         return scrollView
     }()
     
-    private let photoPageLabel: UILabel = {
+    let photoPageLabel: UILabel = {
         let label = UILabel()
         label.backgroundColor = UIColor.customColor(hexCode: .neutral950).withAlphaComponent(0.6)
         label.layer.cornerRadius = 13

--- a/EatsOkay/Sources/Summary/View/SectionOneViewCell.swift
+++ b/EatsOkay/Sources/Summary/View/SectionOneViewCell.swift
@@ -14,6 +14,7 @@ import RxCocoa
 class SectionOneViewCell: UICollectionViewCell {
     static let identifier = "SectionOneViewCell"
     
+    fileprivate let contentsButtonRelay = PublishRelay<Void>()
     var disposeBag = DisposeBag()
     
     required init?(coder: NSCoder) {
@@ -51,12 +52,11 @@ class SectionOneViewCell: UICollectionViewCell {
     }()
     
     private let storeImageView = UIView()
-    private let contentViews: [UIImageView] = {
+    private let contentButtons: [UIButton] = {
         ["DefaultImage", "DefaultImage", "DefaultImage"].map { imageName in
-            let imageView = UIImageView()
-            imageView.image = UIImage(named: imageName)
-            imageView.contentMode = .scaleAspectFit
-            return imageView
+            let button = UIButton()
+            button.imageView?.contentMode = .scaleAspectFit
+            return button
         }
     }()
     
@@ -66,7 +66,7 @@ class SectionOneViewCell: UICollectionViewCell {
         scrollView.addSubview(storeImageView)
         
         
-        contentViews.forEach { storeImageView.addSubview($0) }
+        contentButtons.forEach { storeImageView.addSubview($0) }
         
         [
             scrollView, photoPageLabel
@@ -92,21 +92,21 @@ class SectionOneViewCell: UICollectionViewCell {
         storeImageView.snp.makeConstraints {
             $0.edges.equalToSuperview()
             $0.height.equalToSuperview()
-            $0.width.equalToSuperview().multipliedBy(contentViews.count)
+            $0.width.equalToSuperview().multipliedBy(contentButtons.count)
         }
         
         bgView.snp.makeConstraints { make in
             make.height.equalTo(contentView.snp.height)
         }
         
-        for (index, view) in contentViews.enumerated() {
+        for (index, view) in contentButtons.enumerated() {
             view.snp.makeConstraints {
                 $0.top.bottom.equalToSuperview()
                 $0.width.equalTo(scrollView.snp.width)
                 if index == 0 {
                     $0.leading.equalToSuperview()
                 } else {
-                    $0.leading.equalTo(contentViews[index - 1].snp.trailing)
+                    $0.leading.equalTo(contentButtons[index - 1].snp.trailing)
                 }
             }
         }
@@ -123,14 +123,22 @@ class SectionOneViewCell: UICollectionViewCell {
     func update(with: SummarySectionModel.CellModel) {
         switch with {
         case .summaryImageCell(let data):
+            contentButtons.forEach {
+                $0.rx.tap
+                    .withUnretained(self)
+                    .bind { cell, _ in
+                        cell.contentsButtonRelay.accept(Void())
+                    }
+                    .disposed(by: disposeBag)
+            }
             for (index, urlString) in data.photosUrl.enumerated() {
-                if index < contentViews.count {
-                    if urlString == "DefaultImage" {
-                        contentViews[index].image = UIImage(named: "DefaultImage")
-                    } else if let url = URL(string: urlString), urlString.hasPrefix("https") {
-                        contentViews[index].kf.setImage(with: url)
+                if index < contentButtons.count {
+                    if let url = URL(string: urlString) {
+                        contentButtons[index].kf.setImage(with: url, for: .normal)
+                        contentButtons[index].kf.setImage(with: url, for: .highlighted)
                     } else {
-                        contentViews[index].image = UIImage(named: "DefaultImage")
+                        contentButtons[index].setImage(UIImage(named: "DefaultImage"), for: .normal)
+                        contentButtons[index].setImage(UIImage(named: "DefaultImage"), for: .highlighted)
                     }
                 }
             }
@@ -144,6 +152,11 @@ extension Reactive where Base: SectionOneViewCell {
     var imagePage: Observable<CGPoint> {
         return base.scrollView.rx.contentOffset
             .asObservable() 
+    }
+    
+    var buttonsTapped: Observable<Void> {
+        return base.contentsButtonRelay
+            .asObservable()
     }
 }
 

--- a/EatsOkay/Sources/Summary/View/SectionOneViewCell.swift
+++ b/EatsOkay/Sources/Summary/View/SectionOneViewCell.swift
@@ -11,7 +11,7 @@ import Kingfisher
 import RxSwift
 import RxCocoa
 
-class SectionOneViewCell: UICollectionViewCell {
+final class SectionOneViewCell: UICollectionViewCell {
     static let identifier = "SectionOneViewCell"
     
     fileprivate let contentsButtonRelay = PublishRelay<Void>()
@@ -43,7 +43,7 @@ class SectionOneViewCell: UICollectionViewCell {
         return scrollView
     }()
     
-    let photoPageLabel: UILabel = {
+    private let photoPageLabel: UILabel = {
         let label = UILabel()
         label.backgroundColor = UIColor.customColor(hexCode: .neutral950).withAlphaComponent(0.6)
         label.layer.cornerRadius = 13

--- a/EatsOkay/Sources/Summary/View/SectionThreeViewCell.swift
+++ b/EatsOkay/Sources/Summary/View/SectionThreeViewCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 import SnapKit
 
-class SectionThreeViewCell: UICollectionViewCell {
+final class SectionThreeViewCell: UICollectionViewCell {
     static let identifier = "SectionThreeViewCell"
     
     private let groupFeatureImageView: UIImageView = {

--- a/EatsOkay/Sources/Summary/View/SectionTwoViewCell.swift
+++ b/EatsOkay/Sources/Summary/View/SectionTwoViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-class SectionTwoViewCell: UICollectionViewCell {
+final class SectionTwoViewCell: UICollectionViewCell {
     static let identifier = "SectionTwoViewCell"
     
     required init?(coder: NSCoder) {
@@ -209,7 +209,7 @@ class SectionTwoViewCell: UICollectionViewCell {
 
 extension SectionTwoViewCell {
     // ex) 서울특별시 OO구 OO동 OOOOO을 서울시 OO구로 변환하는 함수
-    func formatAddress(_ fullAddress: String) -> String {
+    private func formatAddress(_ fullAddress: String) -> String {
         // 공백을 기준으로 분리
         let components = fullAddress.components(separatedBy: " ")
         

--- a/EatsOkay/Sources/Summary/View/SummaryViewController.swift
+++ b/EatsOkay/Sources/Summary/View/SummaryViewController.swift
@@ -408,7 +408,7 @@ extension SummaryViewController {
                 cell.rx.buttonsTapped
                     .map { Reactor.Action.imageSeleted }
                     .bind(to: reactor.action)
-                    .disposed(by: disposeBag)
+                    .disposed(by: cell.disposeBag)
                 
                 cell.rx.imagePage
                     .map({ value -> Int in
@@ -433,12 +433,14 @@ extension SummaryViewController {
                     .disposed(by: cell.disposeBag)
                 
                 // photoPageLabel 바인딩
-                reactor.state
+                let currentImagePageInfo: Observable<(Int, Int)> = reactor.state
                     .map { $0.currentImagePage }
-                    .distinctUntilChanged()
-                    .map { index -> NSAttributedString in
+                    .distinctUntilChanged { $0 == $1 }
+                
+                currentImagePageInfo
+                    .map { (index, total) -> NSAttributedString in
                         AttributedStringManager.configureString(
-                            text: "\(index + 1) / 3",
+                            text: "\(index + 1) / \(total)",
                             font: UIFont.customFontForBody(weight: .w500),
                             color: .bgColor,
                             alignment: .center

--- a/EatsOkay/Sources/Summary/View/SummaryViewController.swift
+++ b/EatsOkay/Sources/Summary/View/SummaryViewController.swift
@@ -111,22 +111,22 @@ class SummaryViewController: UIViewController {
     }
     
     private func createCompositionalLayout() -> UICollectionViewCompositionalLayout {
-        let layout = UICollectionViewCompositionalLayout { sectionIndex, environment in
+        let layout = UICollectionViewCompositionalLayout { [weak self] sectionIndex, environment in
             switch sectionIndex {
             case 0:
                 // 첫번째 섹션 레이아웃 만들기
-                return self.createOneSection()
+                return self?.createOneSection()
             case 1:
                 // 두번째 섹션 레이아웃 만들기
-                return self.createTwoSection()
+                return self?.createTwoSection()
             case 2:
                 // 세번째 섹션 레이아웃 만들기
-                return self.createThreeSection()
+                return self?.createThreeSection()
             case 3:
                 // 네번째 섹션 레이아웃 만들기
-                return self.createFourSection()
+                return self?.createFourSection()
             default:
-                return self.createDefaultSectionLayout()
+                return self?.createDefaultSectionLayout()
             }
         }
         return layout

--- a/EatsOkay/Sources/Summary/View/SummaryViewController.swift
+++ b/EatsOkay/Sources/Summary/View/SummaryViewController.swift
@@ -13,7 +13,7 @@ import ReactorKit
 import SafariServices
 import RxDataSources
 
-class SummaryViewController: UIViewController {
+final class SummaryViewController: UIViewController {
     
     typealias Reactor = SummaryReactor
     var reactor: SummaryReactor
@@ -273,7 +273,7 @@ extension SummaryViewController {
         bindState(reactor: reactor)
     }
     
-    func bindAction(reactor: SummaryReactor) {
+    private func bindAction(reactor: SummaryReactor) {
         
         // viewDidLoad 시점시
         reactor.action.onNext(.viewDidLoad)
@@ -297,7 +297,7 @@ extension SummaryViewController {
             .disposed(by: disposeBag)
     }
     
-    func bindState(reactor: SummaryReactor) {
+    private func bindState(reactor: SummaryReactor) {
         
         // 컬렉션 뷰 RxDataSource 바인딩
         reactor.state

--- a/EatsOkay/Sources/Summary/View/SummaryViewController.swift
+++ b/EatsOkay/Sources/Summary/View/SummaryViewController.swift
@@ -17,7 +17,6 @@ class SummaryViewController: UIViewController {
     
     typealias Reactor = SummaryReactor
     var reactor: SummaryReactor
-    private let tapGesture = UITapGestureRecognizer()
     
     var disposeBag = DisposeBag()
     
@@ -296,11 +295,6 @@ extension SummaryViewController {
             .map { Reactor.Action.callButtonTapped }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
-        tapGesture.rx.tapGestureRecognition
-            .map { _ in Reactor.Action.imageSeleted }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
     }
     
     func bindState(reactor: SummaryReactor) {
@@ -411,6 +405,11 @@ extension SummaryViewController {
             case .summaryImageCell:
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SectionOneViewCell.identifier, for: indexPath) as? SectionOneViewCell else { return .init()}
                 
+                cell.rx.buttonsTapped
+                    .map { Reactor.Action.imageSeleted }
+                    .bind(to: reactor.action)
+                    .disposed(by: disposeBag)
+                
                 cell.rx.imagePage
                     .map({ value -> Int in
                         let width = Int(UIScreen.main.bounds.width)
@@ -448,7 +447,6 @@ extension SummaryViewController {
                     .bind(to: cell.photoPageLabel.rx.attributedText)
                     .disposed(by: disposeBag)
                 
-                cell.addGestureRecognizer(tapGesture)
                 cell.update(with: item)
                 return cell
             case .summaryInfoCell:


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
closed: #207

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- SummaryView와 LocationView Gesture 문제로 인한 런타임 에러 발생
  - SummaryView tapGesture 삭제
  - SectionOneVIewCell contentsViews를 contentsButtons로 변경
  - 기존 표시 이미지 3개 고정에서 이미지 최대 3개 동적 표시
  - 기존 예외처리 없음에서 첫 이미지가 DefaultImage일 경우 Detailphotos로 전환 방지 로직 추가
  - SummaryView 접근 제어자 추가

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 동적 표시 로직
- 예외처리 로직

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- SummaryView 런타임 에러 수정하면서 리펙토링도 함께 진행했습니다.
- Detailphotos로 전환 방지 예외처리를 하면서 DetailView의 코드 일부도 수정되었습니다.
- 실기기 빌드 확인 했으나 배포전 TestFlight 먼저 확인바랍니다.

## ✅ Checklist
<!-- 아래 내용은 확인 해주세요. -->
- [x] 주석 및 프린트문 제거 확인
- [x] 컨벤션 준수 확인
